### PR TITLE
Fix Pricing webhook parsing

### DIFF
--- a/src/main/java/com/whatsapp/api/domain/webhook/Pricing.java
+++ b/src/main/java/com/whatsapp/api/domain/webhook/Pricing.java
@@ -1,5 +1,6 @@
 package com.whatsapp.api.domain.webhook;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -7,13 +8,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @param pricingModel Type of pricing model being used. Current supported values are:<ul>                     <li>"CBP" (conversation-based pricing): See Conversation-Based Pricing for rates based on recipient country.</li>                     <li>"NBP" (notification-based pricing): Notifications are also known as Template Messages (click here for details on pricing).</li>                     </ul>                     This pricing model will be deprecated in a future release early 2022.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record Pricing(
 
         @JsonProperty("pricing_model") String pricingModel,
 
         @JsonProperty("category") String category,
 
-        @JsonProperty("billable") boolean billable
+        @JsonProperty("billable") boolean billable,
+
+        @JsonProperty("type") String type
 
 ) {
 


### PR DESCRIPTION
## Summary
- ignore unknown Pricing fields and add optional `type` property

## Testing
- `mvn -q test` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867e4e9e6dc8333b2c653344ffc415d