### PR TITLE
Add PT-BR guide for interactive messages

### DIFF
--- a/docs/mensagens_interativas_pt.md
+++ b/docs/mensagens_interativas_pt.md
@@ -1,0 +1,105 @@
+# Enviando mensagens interativas
+
+Este documento descreve como enviar mensagens interativas (com botões e com listas) usando a biblioteca *whatsapp-business-java-api* e como marcar mensagens como lidas. Também comenta sobre a ausência do recurso de "typing indicator".
+
+## Pré-requisitos
+
+- Java 17 ou superior
+- Dependência da biblioteca conforme especificado no `pom.xml` (versão 0.3.3)
+
+## Mensagens interativas com botões
+
+A biblioteca permite construir uma mensagem do tipo **interactive** e definir o tipo como `button`. O trecho de exemplo abaixo, retirado do README, mostra como montar a estrutura da mensagem:
+
+```java
+var message = MessageBuilder.builder()
+        .setTo(PHONE_NUMBER_1)
+        .buildInteractiveMessage(InteractiveMessage.build()
+                .setAction(new Action()
+                        .addButton(new Button()
+                                .setType(ButtonType.REPLY)
+                                .setReply(new Reply()
+                                        .setId("UNIQUE_BUTTON_ID_1")
+                                        .setTitle("BUTTON_TITLE_1")))
+                        .addButton(new Button()
+                                .setType(ButtonType.REPLY)
+                                .setReply(new Reply()
+                                        .setId("UNIQUE_BUTTON_ID_2")
+                                        .setTitle("BUTTON_TITLE_2")))
+                )
+                .setType(InteractiveMessageType.BUTTON)
+                .setBody(new Body()
+                        .setText("Body message"))
+        );
+```
+
+Fonte: README linhas 234 a 259.
+
+Após construir a mensagem, envie-a utilizando:
+
+```java
+MessageResponse messageResponse = whatsappBusinessCloudApi.sendMessage(PHONE_NUMBER_ID, message);
+```
+
+## Mensagens interativas com listas
+
+O README também apresenta um exemplo completo para mensagens com listas. É possível definir seções e linhas dentro de cada seção:
+
+```java
+var message = MessageBuilder.builder()
+        .setTo(PHONE_NUMBER_1)
+        .buildInteractiveMessage(InteractiveMessage.build()
+                .setAction(new Action()
+                        .setButtonText("BUTTON_TEXT")
+                        .addSection(new Section()
+                                .setTitle("Title 1")
+                                .addRow(new Row()
+                                        .setId("SECTION_1_ROW_1_ID")
+                                        .setTitle("Title 1")
+                                        .setDescription("SECTION_1_ROW_1_DESCRIPTION"))
+                                // outras linhas
+                        )
+                        // outras seções
+                )
+                .setType(InteractiveMessageType.LIST)
+                .setHeader(new Header()
+                        .setType(HeaderType.TEXT)
+                        .setText("Header Text"))
+                .setBody(new Body()
+                        .setText("Body message"))
+                .setFooter(new Footer()
+                        .setText("Footer Text"))
+        );
+```
+
+Fonte: README linhas 274 a 325.
+
+A chamada de envio é a mesma utilizada para outros tipos de mensagem.
+
+## Marcar mensagens como lidas
+
+O projeto implementa o recurso de marcar mensagens como lidas utilizando a classe `ReadMessage` e o método `markMessageAsRead` da classe `WhatsappBusinessCloudApi`:
+
+```java
+ReadMessage message = new ReadMessage("123456");
+var response = whatsappBusinessCloudApi.markMessageAsRead(PHONE_NUMBER_ID, message);
+```
+
+Esse método está definido conforme mostrado no código-fonte:
+
+```java
+public Response markMessageAsRead(String phoneNumberId, ReadMessage message) {
+    return executeSync(whatsappBusinessCloudApiService.markMessageAsRead(phoneNumberId, message));
+}
+```
+
+Fonte: `WhatsappBusinessCloudApi.java` linhas 126 a 136.
+
+## Indicador de digitação
+
+Até o momento não há no repositório nenhuma classe ou método que implemente o envio do campo `typing_indicator`. Caso seja necessário utilizar esse recurso, será preciso estender a biblioteca adicionando a chamada correspondente ao endpoint `/messages` com o payload apropriado.
+
+## Conclusão
+
+Com os exemplos acima é possível enviar mensagens interativas comuns (não-template) utilizando botões ou listas e também marcar mensagens como lidas. A biblioteca já contém classes e builders para montar essas mensagens de forma simples. O recurso de indicador de digitação ainda não está presente.
+


### PR DESCRIPTION
## Summary
- add docs/mensagens_interativas_pt.md explaining how to send interactive list and button messages
- document how to mark messages as read
- note the absence of typing indicator support

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_686ed20fac8c83338be25ca3cd15b2c4