### PR TITLE
Add typing indicator feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ This sdk implements whatsapp business cloud api version v16.0. [See api changelo
 	- [Sending a document message](#sending-a-document-message)
 	- [Sending an image link message](#sending-an-image-link-message)
 	- [Sending an image message](#sending-an-image-message)
-	- [Sending a sticker message](#sending-a-sticker-message)
-	- [Sending a video message](#sending-a-video-message)
+        - [Sending a sticker message](#sending-a-sticker-message)
+        - [Sending a video message](#sending-a-video-message)
+        - [Sending a typing indicator](#sending-a-typing-indicator)
 - [:scroll: Examples (WhatsApp Business Management API)](#scroll-examples-whatsapp-business-management-api)
 	- [Creating a message template](#create-a-message-template)
 	- [Managing phone numbers](/docs/phone_numbers.md#scroll-managing-phone-numbers)
@@ -494,7 +495,23 @@ These can be instantiated through the corresponding factory method of [`Whatsapp
 		.buildVideoMessage(videoMessage);
 
 
-		MessageResponse messageResponse = whatsappBusinessCloudApi.sendMessage(PHONE_NUMBER_ID, message);
+MessageResponse messageResponse = whatsappBusinessCloudApi.sendMessage(PHONE_NUMBER_ID, message);
+```
+
+[:arrow_heading_up: back](#link-links)
+
+---
+
+#### [Sending a typing indicator:](https://github.com/Bindambc/whatsapp-business-java-api/blob/main/src/test/java/com/whatsapp/api/examples/SendTypingIndicatorExample.java)
+
+```java
+        WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TOKEN);
+
+        WhatsappBusinessCloudApi whatsappBusinessCloudApi = factory.newBusinessCloudApi();
+
+        TypingMessage typingMessage = new TypingMessage("<WHATSAPP_MESSAGE_ID>", new TypingIndicator("text"));
+
+        whatsappBusinessCloudApi.sendTypingIndicator(PHONE_NUMBER_ID, typingMessage);
 ```
 
 [:arrow_heading_up: back](#link-links)

--- a/docs/mensagens_interativas_pt.md
+++ b/docs/mensagens_interativas_pt.md
@@ -1,0 +1,111 @@
+# Enviando mensagens interativas
+
+Este documento descreve como enviar mensagens interativas (com botões e com listas) usando a biblioteca *whatsapp-business-java-api* e como marcar mensagens como lidas. Também comenta sobre a ausência do recurso de "typing indicator".
+
+## Pré-requisitos
+
+- Java 17 ou superior
+- Dependência da biblioteca conforme especificado no `pom.xml` (versão 0.3.3)
+
+## Mensagens interativas com botões
+
+A biblioteca permite construir uma mensagem do tipo **interactive** e definir o tipo como `button`. O trecho de exemplo abaixo, retirado do README, mostra como montar a estrutura da mensagem:
+
+```java
+var message = MessageBuilder.builder()
+        .setTo(PHONE_NUMBER_1)
+        .buildInteractiveMessage(InteractiveMessage.build()
+                .setAction(new Action()
+                        .addButton(new Button()
+                                .setType(ButtonType.REPLY)
+                                .setReply(new Reply()
+                                        .setId("UNIQUE_BUTTON_ID_1")
+                                        .setTitle("BUTTON_TITLE_1")))
+                        .addButton(new Button()
+                                .setType(ButtonType.REPLY)
+                                .setReply(new Reply()
+                                        .setId("UNIQUE_BUTTON_ID_2")
+                                        .setTitle("BUTTON_TITLE_2")))
+                )
+                .setType(InteractiveMessageType.BUTTON)
+                .setBody(new Body()
+                        .setText("Body message"))
+        );
+```
+
+Fonte: README linhas 234 a 259.
+
+Após construir a mensagem, envie-a utilizando:
+
+```java
+MessageResponse messageResponse = whatsappBusinessCloudApi.sendMessage(PHONE_NUMBER_ID, message);
+```
+
+## Mensagens interativas com listas
+
+O README também apresenta um exemplo completo para mensagens com listas. É possível definir seções e linhas dentro de cada seção:
+
+```java
+var message = MessageBuilder.builder()
+        .setTo(PHONE_NUMBER_1)
+        .buildInteractiveMessage(InteractiveMessage.build()
+                .setAction(new Action()
+                        .setButtonText("BUTTON_TEXT")
+                        .addSection(new Section()
+                                .setTitle("Title 1")
+                                .addRow(new Row()
+                                        .setId("SECTION_1_ROW_1_ID")
+                                        .setTitle("Title 1")
+                                        .setDescription("SECTION_1_ROW_1_DESCRIPTION"))
+                                // outras linhas
+                        )
+                        // outras seções
+                )
+                .setType(InteractiveMessageType.LIST)
+                .setHeader(new Header()
+                        .setType(HeaderType.TEXT)
+                        .setText("Header Text"))
+                .setBody(new Body()
+                        .setText("Body message"))
+                .setFooter(new Footer()
+                        .setText("Footer Text"))
+        );
+```
+
+Fonte: README linhas 274 a 325.
+
+A chamada de envio é a mesma utilizada para outros tipos de mensagem.
+
+## Marcar mensagens como lidas
+
+O projeto implementa o recurso de marcar mensagens como lidas utilizando a classe `ReadMessage` e o método `markMessageAsRead` da classe `WhatsappBusinessCloudApi`:
+
+```java
+ReadMessage message = new ReadMessage("123456");
+var response = whatsappBusinessCloudApi.markMessageAsRead(PHONE_NUMBER_ID, message);
+```
+
+Esse método está definido conforme mostrado no código-fonte:
+
+```java
+public Response markMessageAsRead(String phoneNumberId, ReadMessage message) {
+    return executeSync(whatsappBusinessCloudApiService.markMessageAsRead(phoneNumberId, message));
+}
+```
+
+Fonte: `WhatsappBusinessCloudApi.java` linhas 126 a 136.
+
+## Indicador de digitação
+
+O repositório agora possui suporte ao envio do campo `typing_indicator` por meio da classe `TypingMessage` e do método `sendTypingIndicator` de `WhatsappBusinessCloudApi`.
+Para exibir o indicador, monte um `TypingMessage` informando o `message_id` recebido no webhook e envie-o:
+
+```java
+TypingMessage typingMessage = new TypingMessage("<WHATSAPP_MESSAGE_ID>", new TypingIndicator("text"));
+whatsappBusinessCloudApi.sendTypingIndicator(PHONE_NUMBER_ID, typingMessage);
+```
+
+## Conclusão
+
+Com os exemplos acima é possível enviar mensagens interativas comuns (não-template) utilizando botões ou listas, marcar mensagens como lidas e exibir o indicador de digitação quando necessário. A biblioteca contém classes e builders para montar todas essas mensagens de forma simples.
+

--- a/src/main/java/com/whatsapp/api/domain/messages/TypingIndicator.java
+++ b/src/main/java/com/whatsapp/api/domain/messages/TypingIndicator.java
@@ -1,0 +1,29 @@
+package com.whatsapp.api.domain.messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Typing indicator object used in TypingMessage.
+ *
+ * @see <a href="https://developers.facebook.com/docs/whatsapp/cloud-api/typing-indicators">API documentation - typing indicators</a>
+ */
+public class TypingIndicator {
+    @JsonProperty("type")
+    private String type;
+
+    public TypingIndicator() {
+    }
+
+    public TypingIndicator(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public TypingIndicator setType(String type) {
+        this.type = type;
+        return this;
+    }
+}

--- a/src/main/java/com/whatsapp/api/domain/messages/TypingMessage.java
+++ b/src/main/java/com/whatsapp/api/domain/messages/TypingMessage.java
@@ -1,0 +1,63 @@
+package com.whatsapp.api.domain.messages;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Object to display a typing indicator while preparing a reply.
+ *
+ * @see <a href="https://developers.facebook.com/docs/whatsapp/cloud-api/typing-indicators">API documentation - typing indicators</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TypingMessage {
+    @JsonProperty("messaging_product")
+    private final String messagingProduct = "whatsapp";
+
+    @JsonProperty("status")
+    private String status = "read";
+
+    @JsonProperty("message_id")
+    private String messageId;
+
+    @JsonProperty("typing_indicator")
+    private TypingIndicator typingIndicator;
+
+    public TypingMessage() {
+    }
+
+    public TypingMessage(String messageId, TypingIndicator typingIndicator) {
+        this.messageId = messageId;
+        this.typingIndicator = typingIndicator;
+    }
+
+    public String getMessagingProduct() {
+        return messagingProduct;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public TypingMessage setStatus(String status) {
+        this.status = status;
+        return this;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public TypingMessage setMessageId(String messageId) {
+        this.messageId = messageId;
+        return this;
+    }
+
+    public TypingIndicator getTypingIndicator() {
+        return typingIndicator;
+    }
+
+    public TypingMessage setTypingIndicator(TypingIndicator typingIndicator) {
+        this.typingIndicator = typingIndicator;
+        return this;
+    }
+}

--- a/src/main/java/com/whatsapp/api/impl/WhatsappBusinessCloudApi.java
+++ b/src/main/java/com/whatsapp/api/impl/WhatsappBusinessCloudApi.java
@@ -6,6 +6,7 @@ import com.whatsapp.api.domain.media.MediaFile;
 import com.whatsapp.api.domain.media.UploadResponse;
 import com.whatsapp.api.domain.messages.Message;
 import com.whatsapp.api.domain.messages.ReadMessage;
+import com.whatsapp.api.domain.messages.TypingMessage;
 import com.whatsapp.api.domain.messages.response.MessageResponse;
 import com.whatsapp.api.domain.phone.TwoStepCode;
 import com.whatsapp.api.domain.response.Response;
@@ -133,6 +134,18 @@ public class WhatsappBusinessCloudApi {
      */
     public Response markMessageAsRead(String phoneNumberId, ReadMessage message) {
         return executeSync(whatsappBusinessCloudApiService.markMessageAsRead(phoneNumberId, message));
+    }
+
+    /**
+     * Display a typing indicator to the user while composing a reply.
+     *
+     * @param phoneNumberId Represents a specific phone number.
+     * @param message       The {@link TypingMessage} object.
+     * @return the response
+     * @see <a href="https://developers.facebook.com/docs/whatsapp/cloud-api/typing-indicators">official documentation</a>
+     */
+    public Response sendTypingIndicator(String phoneNumberId, TypingMessage message) {
+        return executeSync(whatsappBusinessCloudApiService.sendTypingIndicator(phoneNumberId, message));
     }
 
     /**

--- a/src/main/java/com/whatsapp/api/service/WhatsappBusinessCloudApiService.java
+++ b/src/main/java/com/whatsapp/api/service/WhatsappBusinessCloudApiService.java
@@ -4,6 +4,7 @@ import com.whatsapp.api.domain.media.Media;
 import com.whatsapp.api.domain.media.UploadResponse;
 import com.whatsapp.api.domain.messages.Message;
 import com.whatsapp.api.domain.messages.ReadMessage;
+import com.whatsapp.api.domain.messages.TypingMessage;
 import com.whatsapp.api.domain.messages.response.MessageResponse;
 import com.whatsapp.api.domain.phone.TwoStepCode;
 import com.whatsapp.api.domain.response.Response;
@@ -89,6 +90,16 @@ public interface WhatsappBusinessCloudApiService {
      */
     @POST("/" + API_VERSION + "/{Phone-Number-ID}/messages")
     Call<Response> markMessageAsRead(@Path("Phone-Number-ID") String phoneNumberId, @Body ReadMessage message);
+
+    /**
+     * Send typing indicator call.
+     *
+     * @param phoneNumberId the phone number id
+     * @param message       the message
+     * @return the call
+     */
+    @POST("/" + API_VERSION + "/{Phone-Number-ID}/messages")
+    Call<Response> sendTypingIndicator(@Path("Phone-Number-ID") String phoneNumberId, @Body TypingMessage message);
 
     /**
      * Two-step verification call.

--- a/src/test/java/com/whatsapp/api/examples/SendTypingIndicatorExample.java
+++ b/src/test/java/com/whatsapp/api/examples/SendTypingIndicatorExample.java
@@ -1,0 +1,23 @@
+package com.whatsapp.api.examples;
+
+import static com.whatsapp.api.TestConstants.PHONE_NUMBER_ID;
+import static com.whatsapp.api.TestConstants.TOKEN;
+
+import com.whatsapp.api.WhatsappApiFactory;
+import com.whatsapp.api.domain.messages.TypingIndicator;
+import com.whatsapp.api.domain.messages.TypingMessage;
+import com.whatsapp.api.impl.WhatsappBusinessCloudApi;
+
+public class SendTypingIndicatorExample {
+
+    public static void main(String[] args) {
+        WhatsappApiFactory factory = WhatsappApiFactory.newInstance(TOKEN);
+        WhatsappBusinessCloudApi whatsappBusinessCloudApi = factory.newBusinessCloudApi();
+
+        TypingMessage typingMessage = new TypingMessage("<WHATSAPP_MESSAGE_ID>", new TypingIndicator("text"));
+
+        var response = whatsappBusinessCloudApi.sendTypingIndicator(PHONE_NUMBER_ID, typingMessage);
+
+        System.out.println(response);
+    }
+}


### PR DESCRIPTION
## Summary
- implement TypingMessage and TypingIndicator models
- expose sendTypingIndicator API and service methods
- document typing indicator usage in PT-BR guide and README
- provide SendTypingIndicatorExample

## Testing
- `mvn -q test` *(failed: Plugin org.jacoco:jacoco-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_686ed20fac8c83338be25ca3cd15b2c4