### PR TITLE
Fix interactive message type serialization

### DIFF
--- a/src/main/java/com/whatsapp/api/domain/messages/type/InteractiveMessageType.java
+++ b/src/main/java/com/whatsapp/api/domain/messages/type/InteractiveMessageType.java
@@ -40,6 +40,7 @@ public enum InteractiveMessageType {
      *
      * @return the value
      */
+    @com.fasterxml.jackson.annotation.JsonValue
     public String getValue() {
         return value;
     }


### PR DESCRIPTION
## Summary
- use `@JsonValue` for interactive message type enum

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686f9f68ff848333ba45bca30d4cbeb8