### PR TITLE
Adicionar métodos seguros para ListReply

### DIFF
--- a/src/main/java/com/whatsapp/api/domain/webhook/Interactive.java
+++ b/src/main/java/com/whatsapp/api/domain/webhook/Interactive.java
@@ -17,4 +17,21 @@ public record Interactive(
 
         @JsonProperty("button_reply") ButtonReply buttonReply) {
 
+    /**
+     * Checks if the interactive payload contains a list reply.
+     *
+     * @return {@code true} if a list reply is present; otherwise {@code false}
+     */
+    public boolean hasListReply() {
+        return listReply != null;
+    }
+
+    /**
+     * Safely returns the title from the list reply.
+     *
+     * @return the title when available or {@code null}
+     */
+    public String getListReplyTitle() {
+        return listReply != null ? listReply.title() : null;
+    }
 }


### PR DESCRIPTION
## Summary
- adicionar checagem de `listReply`
- expor métodos utilitários para ler com segurança o título da resposta de lista

## Testing
- `mvn test` *(falhou: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6870449d060c8333ad8ef23373f60f2d