### PR TITLE
Atualiza versão da API para v23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Whatsapp business api SDK, written in java. This SDK implements the Official [Wh
 
 The WhatsApp Business API allows medium and large businesses to communicate with their customers at scale. Using the API, businesses can build systems that connect thousands of customers with agents or bots, enabling both programmatic and manual communication. Additionally, you can integrate the API with numerous backend systems, such as CRM and marketing platforms.The library is designed to be simple and flexible, making it ideal for a wide range of use cases.
 
-This sdk implements whatsapp business cloud api version v16.0. [See api changelog](https://developers.facebook.com/docs/whatsapp/business-platform/changelog)
+This sdk implements whatsapp business cloud api version v23.0. [See api changelog](https://developers.facebook.com/docs/whatsapp/business-platform/changelog)
 
 :warning: This project is still under construction. Contributions are welcome.
 

--- a/docs/guia_de_replicacao.md
+++ b/docs/guia_de_replicacao.md
@@ -38,7 +38,7 @@ com.whatsapp.api
 A seguir descrevemos brevemente a responsabilidade de cada subpacote e classes relevantes.
 
 ### configuration
-- **WhatsappApiConfig** – define constantes como a versão da API (`v16.0`) e o domínio base (`https://graph.facebook.com/`). Possui método para alterar esse domínio se necessário.
+- **WhatsappApiConfig** – define constantes como a versão da API (`v23.0`) e o domínio base (`https://graph.facebook.com/`). Possui método para alterar esse domínio se necessário.
 
 ### interceptor
 - **AuthenticationInterceptor** – intercepta requisições HTTP adicionando o cabeçalho `Authorization: Bearer <token>`.

--- a/src/main/java/com/whatsapp/api/configuration/WhatsappApiConfig.java
+++ b/src/main/java/com/whatsapp/api/configuration/WhatsappApiConfig.java
@@ -8,7 +8,7 @@ public class WhatsappApiConfig {
     /**
      * The constant API_VERSION.
      */
-    public final static String API_VERSION = "v16.0";
+    public final static String API_VERSION = "v23.0";
     /**
      * The constant BASE_DOMAIN.
      */


### PR DESCRIPTION
## Summary
- define o valor `v23.0` como versão da API
- documenta o novo número da versão nos arquivos `README` e guia de replicação

## Testing
- `mvn -q test` *(falhou: Could not transfer artifact org.jacoco:jacoco-maven-plugin from https://repo.maven.apache.org/maven2)*

------
https://chatgpt.com/codex/tasks/task_e_68892a5c4d8c83338de9337ec95f8e87